### PR TITLE
Actualización `get_microdata`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,8 @@ Imports:
     curl,
     janitor,
     questionr,
-    tidyr
+    tidyr,
+    readr
 Depends: R (>= 2.10)
 License: MIT + file LICENSE
 Encoding: UTF-8

--- a/R/calculate_poverty.R
+++ b/R/calculate_poverty.R
@@ -15,8 +15,8 @@
 #'
 #'@examples
 #'
-#'base_2016t3 <-  get_microdata(year = 2016,trimester = 3,labels = FALSE)[['base_individual']]
-#'base_2016t4 <- get_microdata(year = 2016,trimester = 4,labels = FALSE)[['base_individual']]
+#'base_2016t3 <-  get_microdata(year = 2016, trimester = 3,type='individual', labels = FALSE)
+#'base_2016t4 <- get_microdata(year = 2016, trimester = 4,type='individual', labels = FALSE)
 #'#'
 #'bases <- dplyr::bind_rows(base_2016t3,base_2016t4)
 #'base_pobreza <- calculate_poverty(base = bases, basket = canastas_reg_example,print_summary=TRUE)

--- a/R/calculate_tabulates.R
+++ b/R/calculate_tabulates.R
@@ -16,7 +16,7 @@
 #'
 #'### descargo la base para el ejemplo ###
 #'
-#'base_2016t3 <-  get_microdata(year = 2016,trimester = 3,labels = FALSE)[['base_individual']]
+#'base_2016t3 <-  get_microdata(year = 2016, trimester = 3,type='individual', labels = FALSE)
 #'
 #'### tabla simple ###
 #'

--- a/R/get_microdata.R
+++ b/R/get_microdata.R
@@ -1,21 +1,21 @@
 #'Descarga de Bases de EPH
 #'@description
-#'Función que descarga bases de la Encuesta Permanente de Hogares del INDEC a partir de 2016
-#'@param year un integer entre 2016:2018
+#'Función que descarga bases de la Encuesta Permanente de Hogares del INDEC a partir de 2003
+#'@param year un integer a partir de 2003
 #'@param trimester un integer con el numero de trimester: 1,2,3,4
+#'@param type tipo de base a descargar: 'individual' ; 'hogar'
 #'@param labels TRUE/FALSE, opcion para labelsr los datos
 #'@details
 #'disclaimer: El script no es un producto oficial de INDEC.
 #'
 #'@examples
 #'
-#'base <- get_microdata(year = 2018, trimester = 1, labels = FALSE)
-#'base_individual <- base[['base_individual']]
-#'base_hogar <- base[['base_hogar']]
+#'base_individual <- get_microdata(year = 2018, trimester = 1,type='individual', labels = FALSE)
+#'base_hogar <- get_microdata(year = 2018, trimester = 1,type='hogar', labels = FALSE)
 #'
 #'@export
 
-get_microdata <- function(year = 2018, trimester = 1,labels = FALSE){
+get_microdata <- function(year = 2018, trimester = 1,type='individual',labels = FALSE){
 
     #controles de los parametros
     assertthat::assert_that(is.numeric(year))
@@ -23,46 +23,17 @@ get_microdata <- function(year = 2018, trimester = 1,labels = FALSE){
     assertthat::assert_that(assertthat::is.flag(labels), msg = "Por favor ingresa TRUE o FALSE")
     assertthat::assert_that(trimester %in% 1:4, msg = "Por favor ingresa un numero de trimeste valido: 1,2,3,4")
 
-    assertthat::assert_that(year>=2016,msg = "Esta funcion solo es valida para las bases a partir de 2016")
+    link = glue::glue('https://github.com/rindec/data/raw/master/eph/{type}/base_{type}_{year}T{trimester}.RDS')
 
-    if (year == 2016 | (year == 2017 & trimester ==1)){
-      if (trimester == 1){
-        trimester <- "1ro"}
-      if (trimester == 2){
-        trimester <- "2do"}
-      if (trimester == 3){
-        trimester <- "3er"}
-      if (trimester == 4){
-        trimester <- "4to"}
-
-      base = paste0("EPH_usu_", trimester, "Trim_", year, "_txt.zip")
-    }
-
-    if (year >= 2018 | (year == 2017 & trimester >=2)){
-      base = paste0("EPH_usu_", trimester, "_Trim_", year, "_txt.zip")
-    }
-
-    link = paste0('https://www.indec.gob.ar/ftp/cuadros/menusuperior/eph/', base)
-    temp <- tempfile()
+    temp <- glue::glue('{tempfile()}.RDS')
 
     check <- NA
-    try(check <- utils::download.file(link,temp,method = 'libcurl'),silent = TRUE)
+
+    try(check <- utils::download.file(link, destfile = temp),silent = TRUE)
+
     assertthat::assert_that(assertthat::noNA(check),msg = "problema con la descarga. Posiblemente un error de la conexion a internet")
 
-    nombres <- purrr::as_vector(utils::unzip(temp, list = TRUE)['Name'])
-    base_hogar_name <- nombres[stringr::str_detect(nombres, 'hog')]
-    base_individual_name <- nombres[stringr::str_detect(nombres, 'ind')]
-
-    base_individual <- utils::read.table(unz(temp,base_individual_name), sep=";", dec=",", header = TRUE, fill = TRUE)
-    if (labels == TRUE) {
-      base_individual <- put_labels_eph(base_individual, base = 'individual')
-    }
-
-    base_hogar <- utils::read.table(unz(temp,base_hogar_name), sep=";", dec=",", header = TRUE, fill = TRUE)
-    if (labels == TRUE) {
-      base_hogar <- put_labels_eph(base_hogar, base = 'hogar')
-    }
-
+    base <- readr::read_rds(temp)
     unlink(temp)
-    bases <- list("base_hogar"=base_hogar,"base_individual"=base_individual)
+    base
   }

--- a/R/get_microdata.R
+++ b/R/get_microdata.R
@@ -22,6 +22,22 @@ get_microdata <- function(year = 2018, trimester = 1,type='individual',labels = 
     assertthat::assert_that(is.numeric(trimester))
     assertthat::assert_that(assertthat::is.flag(labels), msg = "Por favor ingresa TRUE o FALSE")
     assertthat::assert_that(trimester %in% 1:4, msg = "Por favor ingresa un numero de trimeste valido: 1,2,3,4")
+    assertthat::assert_that(type %in% c('individual','hogar'))
+    assertthat::assert_that(!(year==2007 & trimester==3), msg="INDEC advierte: La información correspondiente al tercer trimestre 2007 no está disponible ya que los aglomerados Mar del Plata-Batán, Bahía Blanca-Cerri y Gran La Plata no fueron relevados por causas de orden administrativo, mientras que los datos correspondientes al Aglomerado Gran Buenos Aires no fueron relevados por paro del personal de la EPH.")
+    assertthat::assert_that(!((year==2015 & trimester %in% 3:4)|(year==2016 & trimester ==1)), msg="En el marco de la emergencia estadística el INDEC no publicó la base solicitada.
+                            más informacón en: https://www.indec.gob.ar/ftp/cuadros/sociedad/anexo_informe_eph_23_08_16.pdf")
+
+    if (year %in% 2007:2015) {
+      warning("INDEC advierte:
+'''
+              Advertencia sobre el uso de series estadísticas
+
+Se advierte que las series estadísticas publicadas con posterioridad a enero 2007 y hasta diciembre 2015 deben ser consideradas con reservas, excepto las que ya hayan sido revisadas en 2016 y su difusión lo consigne expresamente. El INDEC, en el marco de las atribuciones conferidas por los decretos 181/15 y 55/16, dispuso las investigaciones requeridas para establecer la regularidad de procedimientos de obtención de datos, su procesamiento, elaboración de indicadores y difusión.
+'''
+más informacón en: https://www.indec.gob.ar/ftp/cuadros/sociedad/anexo_informe_eph_23_08_16.pdf
+")
+    }
+
 
     link = glue::glue('https://github.com/rindec/data/raw/master/eph/{type}/base_{type}_{year}T{trimester}.RDS')
 

--- a/R/organize_labels.R
+++ b/R/organize_labels.R
@@ -5,8 +5,8 @@
 #'@details
 #'disclaimer: El script no es un producto oficial de INDEC.
 #'@examples
-#'df <- get_microdata(year = 2018, trimester = 1, labels = FALSE)
-#'df <- organize_labels(df$base_hogar, base='hogar')
+#'df <- get_microdata(year = 2018, trimester = 1,type='hogar', labels = FALSE)
+#'df <- organize_labels(df, base='hogar')
 #'@export
 
 

--- a/R/orgnize_panels.R
+++ b/R/orgnize_panels.R
@@ -12,8 +12,8 @@
 #' @export
 #'
 #' @examples
-#' base_1t_2018 <- get_microdata(year = 2018,trimester = 1)[[2]]
-#' base_2t_2018 <- get_microdata(year = 2018,trimester = 2)[[2]]
+#' base_1t_2018 <- get_microdata(year = 2018, trimester = 1,type='individual', labels = FALSE)
+#' base_2t_2018 <- get_microdata(year = 2018, trimester = 2,type='individual', labels = FALSE)
 #'
 #' lista_bases <- list(base_1t_2018,base_2t_2018)
 #' pool_trimestral <- orgnize_panels(bases = lista_bases,

--- a/man/calculate_poverty.Rd
+++ b/man/calculate_poverty.Rd
@@ -28,8 +28,8 @@ Función para calcular la pobreza e indigencia siguiendo la metodología de lín
 }
 \examples{
 
-base_2016t3 <-  get_microdata(year = 2016,trimester = 3,labels = FALSE)[['base_individual']]
-base_2016t4 <- get_microdata(year = 2016,trimester = 4,labels = FALSE)[['base_individual']]
+base_2016t3 <-  get_microdata(year = 2016, trimester = 3,type='individual', labels = FALSE)
+base_2016t4 <- get_microdata(year = 2016, trimester = 4,type='individual', labels = FALSE)
 #'
 bases <- dplyr::bind_rows(base_2016t3,base_2016t4)
 base_pobreza <- calculate_poverty(base = bases, basket = canastas_reg_example,print_summary=TRUE)

--- a/man/calculate_tabulates.Rd
+++ b/man/calculate_tabulates.Rd
@@ -38,7 +38,7 @@ Función para crear tabulados uni o bivariados con ponderacion, totales parciale
 
 ### descargo la base para el ejemplo ###
 
-base_2016t3 <-  get_microdata(year = 2016,trimester = 3,labels = FALSE)[['base_individual']]
+base_2016t3 <-  get_microdata(year = 2016, trimester = 3,type='individual', labels = FALSE)
 
 ### tabla simple ###
 

--- a/man/get_microdata.Rd
+++ b/man/get_microdata.Rd
@@ -4,12 +4,15 @@
 \alias{get_microdata}
 \title{Descarga de Bases de EPH}
 \usage{
-get_microdata(year = 2018, trimester = 1, labels = FALSE)
+get_microdata(year = 2018, trimester = 1, type = "individual",
+  labels = FALSE)
 }
 \arguments{
 \item{year}{un integer entre 2016:2018}
 
 \item{trimester}{un integer con el numero de trimester: 1,2,3,4}
+
+\item{type}{tipo de base a descargar: 'individual' ; 'hogar'}
 
 \item{labels}{TRUE/FALSE, opcion para labelsr los datos}
 }
@@ -21,8 +24,7 @@ disclaimer: El script no es un producto oficial de INDEC.
 }
 \examples{
 
-base <- get_microdata(year = 2018, trimester = 1, labels = FALSE)
-base_individual <- base[['base_individual']]
-base_hogar <- base[['base_hogar']]
+base_individual <- get_microdata(year = 2018, trimester = 1,type='individual', labels = FALSE)
+base_hogar <- get_microdata(year = 2018, trimester = 1,type='hogar', labels = FALSE)
 
 }

--- a/man/get_microdata.Rd
+++ b/man/get_microdata.Rd
@@ -4,8 +4,8 @@
 \alias{get_microdata}
 \title{Descarga de Bases de EPH}
 \usage{
-get_microdata(year = 2018, trimester = 1, type = "individual",
-  labels = FALSE)
+get_microdata(year = 2018, trimester = NA, wave = NA,
+  type = "individual", labels = FALSE)
 }
 \arguments{
 \item{year}{un integer a partir de 2003}

--- a/man/get_microdata.Rd
+++ b/man/get_microdata.Rd
@@ -8,7 +8,7 @@ get_microdata(year = 2018, trimester = 1, type = "individual",
   labels = FALSE)
 }
 \arguments{
-\item{year}{un integer entre 2016:2018}
+\item{year}{un integer a partir de 2003}
 
 \item{trimester}{un integer con el numero de trimester: 1,2,3,4}
 
@@ -17,7 +17,7 @@ get_microdata(year = 2018, trimester = 1, type = "individual",
 \item{labels}{TRUE/FALSE, opcion para labelsr los datos}
 }
 \description{
-Función que descarga bases de la Encuesta Permanente de Hogares del INDEC a partir de 2016
+Función que descarga bases de la Encuesta Permanente de Hogares del INDEC a partir de 2003
 }
 \details{
 disclaimer: El script no es un producto oficial de INDEC.

--- a/man/organize_labels.Rd
+++ b/man/organize_labels.Rd
@@ -18,6 +18,6 @@ Función para etiquetar las bases de la Encuesta Permanente de Hogares.
 disclaimer: El script no es un producto oficial de INDEC.
 }
 \examples{
-df <- get_microdata(year = 2018, trimester = 1, labels = FALSE)
-df <- organize_labels(df$base_hogar, base='hogar')
+df <- get_microdata(year = 2018, trimester = 1,type='hogar', labels = FALSE)
+df <- organize_labels(df, base='hogar')
 }

--- a/man/orgnize_panels.Rd
+++ b/man/orgnize_panels.Rd
@@ -24,8 +24,8 @@ de especificar una serie consecutiva de bases, variables y el largo de la window
 disclaimer: El script no es un producto oficial de INDEC.
 }
 \examples{
-base_1t_2018 <- get_microdata(year = 2018,trimester = 1)[[2]]
-base_2t_2018 <- get_microdata(year = 2018,trimester = 2)[[2]]
+base_1t_2018 <- get_microdata(year = 2018, trimester = 1,type='individual', labels = FALSE)
+base_2t_2018 <- get_microdata(year = 2018, trimester = 2,type='individual', labels = FALSE)
 
 lista_bases <- list(base_1t_2018,base_2t_2018)
 pool_trimestral <- orgnize_panels(bases = lista_bases,


### PR DESCRIPTION
Modifico la función `get_microdata` para que  descargue las bases de [rindec/data](https://github.com/rindec/data/tree/master/eph)

En este repositorio agregamos todas las bases desde 1995 (con el objetivo de agregar todas las bases desde el comienzo a medida que se consigan y normalicen los nombres)

Para que la función pueda leer bases de la EPH puntual, agregamos el parámetro `wave` como alternativa a `trimester` y los controles de flujo necesarios para que el usuario defina el parámetro correcto en cada caso. 

A su vez, agregamos las advertencias hechas por el indec para las bases de 2007-2015, y las explicaciiones de las bases faltantes para 2007 (3er), 2015 (3er y 4to) y 2016 (1er).